### PR TITLE
Move video and map overlays to MarzipanoPage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,6 @@
 import MarzipanoPage from "./components/MarzipanoPage";
 import VideoOverlay from "@components/VideoOverlay";
 import { useVideoStore } from "@/context/useVideoStore";
-import MapOverlay from "./components/MapOverlay";
 
 const App = () => {
   const { videoLink, isVideoVisible, closeVideo } = useVideoStore();
@@ -11,7 +10,6 @@ const App = () => {
     <>
       <MarzipanoPage />
       {isVideoVisible && videoLink && <VideoOverlay videoLink={videoLink} onClose={closeVideo} />}
-      <MapOverlay />
     </>
   );
 };

--- a/src/components/MarzipanoPage.tsx
+++ b/src/components/MarzipanoPage.tsx
@@ -6,10 +6,14 @@ import { AppData } from '@/types/marzipano-types';
 import { Viewer, Scene as SceneObjects } from 'marzipano';
 import Navbar from '@components/Navbar';
 import { useSceneStore } from '@/context/useSceneStore';
+import MapOverlay from './MapOverlay';
+import { useVideoStore } from '@/context/useVideoStore';
+import VideoOverlay from './VideoOverlay';
 
 const MarzipanoPage: React.FC = () => {
   const panoRef = useRef<HTMLDivElement>(null);
   const { currentSceneIndex } = useSceneStore();
+  const { closeVideo, isVideoVisible, videoLink } = useVideoStore();
 
   const { viewer, sceneObjects, isAutorotating, toggleAutorotation } = useMarzipano(panoRef, APP_DATA as AppData, currentSceneIndex);
 
@@ -39,6 +43,8 @@ const MarzipanoPage: React.FC = () => {
           currentSceneIndex={currentSceneIndex}
         />
       )}
+      <MapOverlay />
+      {isVideoVisible && videoLink && <VideoOverlay videoLink={videoLink} onClose={closeVideo} />}
     </div>
   );
 };


### PR DESCRIPTION
Previously, the video overlay and map overlay were not displayed correctly in full-screen mode because they were part of the App component. This commit moves these overlays to the MarzipanoPage component, resolving the issue and ensuring they are now shown correctly in full screen.